### PR TITLE
Fixes

### DIFF
--- a/philistine/mne/io.py
+++ b/philistine/mne/io.py
@@ -83,6 +83,7 @@ def _write_vmrk_file(vmrk_fname, eeg_fname, events):
         print(r';Exported from MNE-Python using philistine {}'.format(__version__), file=fout)
         print(r'', file=fout)
         print(r'[Common Infos]', file=fout)
+        print(r'Codepage=UTF-8', file=fout)
         print(r'DataFile={}'.format(eeg_fname), file=fout)
         print(r'', file=fout)
         print(r'[Marker Infos]', file=fout)
@@ -120,6 +121,7 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, raw,
         print(r';Exported from MNE-Python using philistine', file=fout)
         print(r'', file=fout)
         print(r'[Common Infos]', file=fout)
+        print(r'Codepage=UTF-8', file=fout)
         print(r'DataFile={}'.format(eeg_fname), file=fout)
         print(r'MarkerFile={}'.format(vmrk_fname), file=fout)
 

--- a/philistine/mne/io.py
+++ b/philistine/mne/io.py
@@ -118,7 +118,7 @@ def _write_vhdr_file(vhdr_fname, vmrk_fname, eeg_fname, raw,
 
     with open(vhdr_fname, 'w', encoding='utf-8') as fout:
         print(r'Brain Vision Data Exchange Header File Version 1.0', file=fout)
-        print(r';Exported from MNE-Python using philistine', file=fout)
+        print(r';Exported from MNE-Python using philistine {}'.format(__version__), file=fout)
         print(r'', file=fout)
         print(r'[Common Infos]', file=fout)
         print(r'Codepage=UTF-8', file=fout)


### PR DESCRIPTION
In the `.vhdr` and `.vmrk` that I have, there is usually a `Codepage=UTF-8` declaration. I added this here as well, because you are writing in UTF-8.

Additionally, I added to printing the philistine version used in the header file.

PS: Why are your issues disabled? Are PRs and bug reports not wanted at this point? :-)